### PR TITLE
Add ccmonitor 0.1.10

### DIFF
--- a/Casks/c/ccmonitor.rb
+++ b/Casks/c/ccmonitor.rb
@@ -1,0 +1,26 @@
+cask "ccmonitor" do
+  version "0.1.10"
+  sha256 "b07a9ca094cfa44f33c2c61381a0c3c9ab787524dcbc89af5d054a5c02697001"
+
+  url "https://github.com/K9i-0/ClaudeCodeMonitor/releases/download/v#{version}/ClaudeCodeMonitor-#{version}.dmg"
+  name "Claude Code Monitor"
+  desc "Monitor Claude Code API usage and costs in your menubar"
+  homepage "https://github.com/K9i-0/ClaudeCodeMonitor"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates false
+  depends_on macos: ">= :ventura"
+
+  app "ClaudeCodeMonitor.app"
+
+  uninstall quit: "com.k9i.claude-code-monitor"
+
+  zap trash: [
+    "~/Library/Application Support/Claude Code Monitor",
+    "~/Library/Preferences/com.k9i.claude-code-monitor.plist",
+  ]
+end


### PR DESCRIPTION
### Pre-submission checklist
- [x] The cask was submitted via a pull request to the correct repo (homebrew-cask)
- [x] I've checked the cask doesn't already exist with `brew search ccmonitor`
- [x] I've run `brew audit --new ccmonitor` and addressed any issues
- [x] I've run `brew style --fix Casks/c/ccmonitor.rb` and fixed any style issues
- [x] I've checked the cask installs and uninstalls successfully
- [x] The app is stable and reproducible (not a beta or nightly build)

### Description
Claude Code Monitor is a macOS menubar application that monitors Claude Code API usage and costs in real-time.

This app wraps the [ccusage](https://github.com/ryoppippi/ccusage) CLI tool to provide visual, easy-to-understand usage tracking for Claude Code.

### Additional Information
- The app uses ad-hoc code signing, which is acceptable for Homebrew Cask
- Requires Node.js runtime for the ccusage CLI tool integration
- App runs as menubar-only (LSUIElement)
- Supports macOS 13.0 (Ventura) and later

### Release URL
https://github.com/K9i-0/ClaudeCodeMonitor/releases/tag/v0.1.10